### PR TITLE
Updates to latest wazero

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ Steps to reproduce the issue:
 1. Build the Go binary:
 
    ```
-   GO_ENABLED=0 go build .
+   GO_ENABLED=0 GOOS=linux go build .
    ```
 
 1. Build the Docker image:
 
    ```
-   docker build . -t wazero-wasi-test
+   docker build --platform linux/amd64 . -t wazero-wasi-test
+   ```
+
+2. Run the Docker image
+
+   ```
+   docker run --rm wazero-wasi-test
    ```

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/olivierlemasle/wazero-wasi-test
 
 go 1.18
 
-require github.com/tetratelabs/wazero v0.0.0-20220819101114-6c2712fd00fc
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-github.com/tetratelabs/wazero v0.0.0-20220819101114-6c2712fd00fc h1:FYxg+8iJb1u/s7hmzQjKxCmrWbqFh7EwN29KVBa+K9o=
-github.com/tetratelabs/wazero v0.0.0-20220819101114-6c2712fd00fc/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.1 h1:bUZ4vf21c36RmgA3enNOlLgPElEVDYoRJJ9+McRGF6Q=
+github.com/tetratelabs/wazero v1.0.0-pre.1/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 //go:embed hello-world-rs.wasm
@@ -25,8 +25,7 @@ func main() {
 }
 
 func compileAndRun(ctx context.Context, name string, wasm []byte) {
-	runtimeConfig := wazero.NewRuntimeConfig().WithWasmCore2()
-	runtime := wazero.NewRuntimeWithConfig(ctx, runtimeConfig)
+	runtime := wazero.NewRuntime(ctx)
 	defer runtime.Close(ctx)
 
 	if _, err := wasi_snapshot_preview1.Instantiate(ctx, runtime); err != nil {
@@ -34,7 +33,7 @@ func compileAndRun(ctx context.Context, name string, wasm []byte) {
 	}
 
 	fmt.Printf("Compilation of %s... ", name)
-	compiled, err := runtime.CompileModule(ctx, wasm, wazero.NewCompileConfig())
+	compiled, err := runtime.CompileModule(ctx, wasm)
 	if err != nil {
 		log.Panicln(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

Notably, this improves performance and changes host function syntax.